### PR TITLE
bugs in stripe_managed

### DIFF
--- a/app/services/stripe_managed.rb
+++ b/app/services/stripe_managed.rb
@@ -40,7 +40,7 @@ class StripeManaged < Struct.new( :user )
         stripe_user_id: @account.id,
         secret_key: @account.keys.secret,
         publishable_key: @account.keys.publishable,
-        stripe_account_status: managed_status
+        stripe_account_status: account_status
       )
     end
 

--- a/app/services/stripe_managed.rb
+++ b/app/services/stripe_managed.rb
@@ -17,10 +17,10 @@ class StripeManaged < Struct.new( :user )
         managed: true,
         country: country,
         email: user.email,
-        decline_charge_on: {
-          cvc_failure: true,
-          avs_failure: true
-        },
+        # decline_charge_on: {
+        #   cvc_failure: true,
+        #   avs_failure: true
+        # },
         tos_acceptance: {
           ip: ip,
           date: Time.now.to_i

--- a/app/services/stripe_managed.rb
+++ b/app/services/stripe_managed.rb
@@ -79,6 +79,11 @@ class StripeManaged < Struct.new( :user )
           end
         end
 
+        # add other required fields
+        new_legal_entity["personal_address"] = new_legal_entity["address"]
+        new_legal_entity[:verification] = {} # would be an empty string, must be a hash
+        new_legal_entity[:type] = "individual"
+
         account.legal_entity = new_legal_entity
         account.save
       end

--- a/app/views/users/_settings.html.haml
+++ b/app/views/users/_settings.html.haml
@@ -96,6 +96,11 @@
                           { class: 'form-control' }
 
                   .form-group
+                    %label.control-label.col-xs-12.col-sm-3 Last Four Digits of SSN:
+                    .col-xs-12.col-sm-9
+                      %input.form-control{ type: 'text', name: 'legal_entity[ssn_last_4]' }
+
+                  .form-group
                     %label.control-label.col-xs-12.col-sm-3 Address Line 1:
                     .col-xs-12.col-sm-9
                       %input.form-control{ type: 'text', name: 'legal_entity[address][line1]', value: manager.legal_entity.address.line1 }


### PR DESCRIPTION
OK, these changes were enough to get managed accounts working for the US.

See the commit messages for a more complete explanation, but in summary:

ab52ee5 and 7f76021 fix clear bugs and should definitely be pulled.

58f05e2 and b4139fd are additional changes that made managed accounts work for me and should probably be pulled:

Stripe now requires submitting a `verification` when creating a managed account. It can be a scanned document, the last 4 digits of an SSN, or I think an EIN for a corporate account. In the interest of a simple solution, I added an `ssn_last_4` form field, and did not include functionality for choosing a different verification scheme. 

I don't think Canadian people have SSNs, and the managed account public beta does include Canada, so this is probably not ideal.
