### PR TITLE
Modify setting of connected publishable account key in subscribe.coffee

### DIFF
--- a/app/assets/javascripts/app/subscribe.coffee
+++ b/app/assets/javascripts/app/subscribe.coffee
@@ -17,7 +17,7 @@ $(document).ready ->
 
   handler = StripeCheckout.configure
     # The publishable key of the **connected account**.
-    key: window.stripePublishableKey
+    key: window.publishable.connected
 
     # The email of the logged in user.
     email: window.currentUserEmail

--- a/app/assets/javascripts/app/subscribe.coffee
+++ b/app/assets/javascripts/app/subscribe.coffee
@@ -13,11 +13,12 @@ $(document).ready ->
   subscribeButton = $('.subscribe-button')
   planButtons = $('.plan-choice')
   form = subscribeButton.closest('form')
+  destination = form.find('select[name=charge_on]')
   indicator = form.find('.indicator').height( form.outerHeight() )
 
   handler = StripeCheckout.configure
     # The publishable key of the **connected account**.
-    key: window.publishable.connected
+    key: window.publishable[destination.val()]
 
     # The email of the logged in user.
     email: window.currentUserEmail


### PR DESCRIPTION
- [x] Fix publishable key setting for subscriptions
- [x] Ready For Review

The StripeCheckout key was being set with stripePublishableKey, which is not available for whatever reason. This caused an error to be thrown by stripe checkout, warning to set the publishable key. Instead, of using stripePublishableKey, we use the window.publishable object.
